### PR TITLE
Upgrade to Alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12 AS build
+FROM alpine:3.13 AS build
 WORKDIR /usr/local/src/ssh
 COPY resources/openssh.patch .
 COPY resources/bsd-compatible-realpath.patch .


### PR DESCRIPTION
3.13 is the latest stable branch of Alpine Linux:
https://git.alpinelinux.org/aports/log/?h=3.13-stable