### PR TITLE
Use POSIX-compatible string comparator in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN OPENSSH_VERSION='7.3p1' && \
     curl -s -O "https://ftp.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-${OPENSSH_VERSION}.tar.gz" && \
     CHECKSUM=$(sha256sum "openssh-${OPENSSH_VERSION}.tar.gz" | awk '{print $1;}') && \
     echo "Checksum is $CHECKSUM" && \
-    [ "$CHECKSUM" == "$ARCHIVE_SHA_256" ] && \
+    [ "$CHECKSUM" = "$ARCHIVE_SHA_256" ] && \
     echo "Checksum is valid" && \
     tar xzf "openssh-${OPENSSH_VERSION}.tar.gz" && \
     cd "openssh-${OPENSSH_VERSION}" && \


### PR DESCRIPTION
Use `=` instead of `==` for string comparisons in `Dockerfile`, as per
the manual page of test(1), `=` is conform with the IEEE Std 1003.2
(``POSIX.2'') specification, whereas `==` is an extension of this
specification.

Newer versions of Docker appear to have dropped support for `==` in
test(1) brackets.