### PR TITLE
Remove realpath patch from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM alpine:3.18 AS build
 WORKDIR /usr/local/src/ssh
 COPY resources/openssh-9.3p1.patch .
-COPY resources/bsd-compatible-realpath.patch .
 RUN OPENSSH_VERSION='9.3p1' && \
     ARCHIVE_SHA_256='e9baba7701a76a51f3d85a62c383a3c9dcd97fa900b859bc7db114c1868af8a8' && \
     apk add --virtual .build-deps \

--- a/README.md
+++ b/README.md
@@ -71,5 +71,5 @@ The patch bsd-compatible-realpath.patch is provided by
 
 # Copyright
 
-Fabian Foerg, Gotham Digital Science, 2015-2022
+Fabian Foerg, Gotham Digital Science, 2015-2023
 


### PR DESCRIPTION
Previous commit removed the patch file without removing the Dockerfile `COPY` instruction for it:
https://github.com/AonCyberLabs/SSH-Weak-DH/commit/5835126eb92b87cab7bf71aca3396c9a0a7bbaf1