### PR TITLE
Remove mention of realpath patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,6 @@ follows:
 ```
 where `hostname` and `port` are the scanner arguments as explained before.
 
-# Acknowledgments
-
-The patch bsd-compatible-realpath.patch is provided by
-[Alpine Linux](https://git.alpinelinux.org/cgit/aports/plain/main/openssh/bsd-compatible-realpath.patch).
-
 # Copyright
 
 Fabian Foerg, Gotham Digital Science, 2015-2023


### PR DESCRIPTION
The realpath patch is not needed anymore and was removed in https://github.com/AonCyberLabs/SSH-Weak-DH/commit/5835126eb92b87cab7bf71aca3396c9a0a7bbaf1

Remove the reference in README.md