### PR TITLE
Upgrade uv to 0.7.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /usr/local/src/dh-groups
 RUN curl -s -S -L -O 'https://raw.githubusercontent.com/cryptosense/diffie-hellman-groups/04610a10e13db3a69c740bebac9cb26d53c520d3/gen/common.json'
 WORKDIR /app
 RUN apk add --no-cache python3
-COPY --from=ghcr.io/astral-sh/uv:0.6 /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.7 /uv /bin/
 COPY resources/.python-version .
 COPY resources/pyproject.toml .
 COPY resources/uv.lock .


### PR DESCRIPTION
- Upgrade uv to latest 0.7.x from latest 0.6.y.
- Do not copy uvx, as it is not needed.